### PR TITLE
Fix: Edit link in Mina Overview page

### DIFF
--- a/src/pages/Docs.re
+++ b/src/pages/Docs.re
@@ -82,11 +82,20 @@ module Style = {
 module EditLink = {
   [@react.component]
   let make = (~route) => {
+    /*
+       Check if we are on the `Mina Overview` page. If so, we specify the index.mdx file.
+       Otherwise the route binding will hold the correct .mdx to edit.
+     */
+    let href =
+      switch (route) {
+      | "/en" => Constants.minaDocsEditLink ++ route ++ "/index.mdx"
+      | _ => Constants.minaDocsEditLink ++ route ++ ".mdx"
+      };
     <a
       name="Edit Link"
       target="_blank"
       rel="noopener"
-      href={Constants.minaDocsEditLink ++ route ++ ".mdx"}
+      href
       className=Style.editLink>
       <span className=Theme.Type.link> {React.string("Edit ")} </span>
       <span className=Style.editLink__icon>


### PR DESCRIPTION
The URL bindings we use will not have the correct filename information if we are on the 'Mina Overview' page. On this page, the route binding will specify `en.mdx` as the file to edit which is a 404 on our Github. Add a special check to see if we are on this page and link to the corresponding `index.mdx` file on our Github.