### PR TITLE
Changed broken links to match those on footer

### DIFF
--- a/pages/en/index.mdx
+++ b/pages/en/index.mdx
@@ -13,9 +13,9 @@ This breakthrough is made possible due to zk-SNARKs - a type of succinct cryptog
 
 ## How does Mina work?
 
-How does a ‘succinct blockchain’ work? Read our [technical white paper](https://minaprotocol.com/static/pdf/technicalWhitepaper.pdf) to learn more about our cryptographic preliminaries and the succinct blockchain construction used in Mina.
+How does a ‘succinct blockchain’ work? Read our [technical white paper](https://minaprotocol.com/wp-content/uploads/technicalWhitepaper.pdf) to learn more about our cryptographic preliminaries and the succinct blockchain construction used in Mina.
 
-Check out our [economics white paper](https://minaprotocol.com/static/pdf/economicsWhitepaper.pdf) to learn about the roles within Mina Protocol, the incentive design and the monetary policy.
+Check out our [economics white paper](https://minaprotocol.com/wp-content/uploads/economicsWhitepaper.pdf) to learn about the roles within Mina Protocol, the incentive design and the monetary policy.
 
 ## Try Mina
 


### PR DESCRIPTION
Changed broken links for Whitepapers to the same link as on the main page footer.