### PR TITLE
Defaulted text to 'mina' in DaemonCommandExample component

### DIFF
--- a/src/components/DocsComponents.re
+++ b/src/components/DocsComponents.re
@@ -220,7 +220,7 @@ module Rule =
   });
 
 module DaemonCommandExample = {
-  let defaultArgs = ["coda daemon", "-peer-list ~/peers.txt"];
+  let defaultArgs = ["mina daemon", "-peer-list ~/peers.txt"];
   [@react.component]
   let make = (~args: array(string)=[||]) => {
     let allArgs = defaultArgs @ Array.to_list(args);


### PR DESCRIPTION
The DaemonCommandExample component had a default argument that pointed towards `coda`. Added a fix to point to `mina` instead.