### PR TITLE
Use URL to link to blog post

### DIFF
--- a/pages/en/snarks/index.mdx
+++ b/pages/en/snarks/index.mdx
@@ -7,7 +7,7 @@ SNARKs are a powerful cryptographic tool that enable applications
 that give users unprecedented levels of oversight and privacy.
 They are also a key-ingredient in building scalable decentralized systems like Mina.
 
-For a high-level overview, check out [this blogpost](/blog/zero-knowledge-proofs-an-intuitive-explanation).
+For a high-level overview, check out [this blogpost](https://minaprotocol.com/blog/zero-knowledge-proofs-an-intuitive-explanation).
 
 **snarky** is a domain specific language for using SNARKs.
 This section is intended to be a guide on how to get started using SNARKs in


### PR DESCRIPTION
The documentation is hosted on the `docs` subdomain at https://docs.minaprotocol.com/
Hence linking to a blog post doesn't work with an absolute link starting at the root, it must
be a full URL.