### PR TITLE
Update connecting.mdx

### DIFF
--- a/pages/en/using-mina/connecting.mdx
+++ b/pages/en/using-mina/connecting.mdx
@@ -17,8 +17,9 @@ First remove any previously installed version of the daemon to prevent any error
 ```
 sudo apt-get remove -y mina-testnet-postake-medium-curves
 echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/mina.list
+sudo apt-get install --yes apt-transport-https
 sudo apt-get update
-sudo apt-get install -y curl unzip mina-mainnet=1.1.5-a42bdee
+sudo apt-get install --yes curl unzip mina-mainnet=1.1.5-a42bdee
 ```
 
 Check that daemon installed correctly by running `mina version`. The output should read `Commit a42bdeef6b0c15ee34616e4df76c882b0c5c7c2a on branch master`.


### PR DESCRIPTION
Two changes:

+ Debian 9 doesn't come with `apt-transport-https` which is required to pull the mina repo
+ `-y` is nice, but `--yes` is better.