### PR TITLE
Update connecting.mdx

### DIFF
--- a/pages/en/using-mina/connecting.mdx
+++ b/pages/en/using-mina/connecting.mdx
@@ -58,7 +58,7 @@ CODA_PRIVKEY_PASS="private key password"
 EXTRA_FLAGS=" --file-log-level Debug"
 ```
 
-You can add extra flags later to `EXTRA_FLAGS` as you see fit.
+You can add extra flags later to `EXTRA_FLAGS` as you see fit. E.g. the `--limited-graphql-port 3095` when running the [Block Producer Sidecar](/docs/advanced/bp-sidecar).
 
 Mina will be looking for its peers in a file called `~/peers.txt`, so run the following command to create it:
 


### PR DESCRIPTION
The Block Producer Side Car page said:

> Further instructions can be found on the connecting page.

But there were none. I added those instructions.