### PR TITLE
fix: Commented out `StatusBadge` on Navbar

### DIFF
--- a/src/components/Nav.re
+++ b/src/components/Nav.re
@@ -283,13 +283,13 @@ let make = (~dark=false) => {
       </Next.Link>
       <p className=Styles.docsLabel> {React.string("Documentation")} </p>
     </div>
-    <span className=Styles.statusBadgeContainer>
+    /*<span className=Styles.statusBadgeContainer>
       <h4 className=Styles.statusBadge__header>
         {React.string("Devnet Status: ")}
       </h4>
       <span className=Styles.statusBadge>
         <StatusBadge service=`Devnet />
       </span>
-    </span>
+    </span>*/
   </header>;
 };


### PR DESCRIPTION
The `StatusBadge` component was giving issues due to the status page not working correctly. As a fix, for the time being, we just comment out the component until the status page is up again.