### PR TITLE
Add a fix to the mobile nav menu to allow scroll

### DIFF
--- a/src/components/DropdownNav.re
+++ b/src/components/DropdownNav.re
@@ -2,6 +2,8 @@ module Styles = {
   open Css;
   let dropdown =
     style([
+      maxHeight(`vh(90.)),
+      overflowY(`scroll),
       backgroundColor(Theme.Colors.white),
       width(`percent(100.)),
       border(`px(1), `solid, Theme.Colors.digitalBlack),


### PR DESCRIPTION
Makes the docs navigation menu scrollable when you open multiple items. See a demo of the behavior below:

In response too https://github.com/MinaProtocol/docs/issues/50

![scroll-demo](https://user-images.githubusercontent.com/9512405/121442199-ff671380-c93f-11eb-832a-b843e9c194b0.gif)
