### PR TITLE
Fix the Atlassian Status Page 

### DIFF
--- a/src/Constants.re
+++ b/src/Constants.re
@@ -7,13 +7,13 @@ let genesisGrantApplication = "https://share.hsforms.com/1y-QXRVSgQJ6nFnzbbYv_Pg
 let projectGrantApplication = "https://forms.gle/ekPwDKE1BArTqVCu9";
 
 let minaProtocolUrl = "https://minaprotocol.com/";
-let minaDocsUrl = "https://docs.minaprotocol.com/"
+let minaDocsUrl = "https://docs.minaprotocol.com/";
 let o1LabsUrl = "https://o1labs.org/";
 let githubUrl = "https://github.com/";
 let twitterUrl = "https://twitter.com/";
 let linkedInUrl = "https://linkedin.com/in/";
 
-let minaStatus = "https://status.minaprotocol.com";
+let minaStatus = "https://minaprotocol.statuspage.io/";
 let minaSupport = "https://support.minaprotocol.com/";
 
 let minaDiscordSocial = "https://bit.ly/MinaDiscord";


### PR DESCRIPTION
Target the default Atlassian Status page as a workaround while we fix our settings for `https://status.minaprotocol.com`