### PR TITLE
fix devnet docker image name

### DIFF
--- a/pages/en/advanced/connecting-devnet.mdx
+++ b/pages/en/advanced/connecting-devnet.mdx
@@ -63,7 +63,7 @@ docker run --name mina -d \
 -p 8302:8302 \
 --restart=always \
 --mount "type=bind,source=`pwd`/.mina-config,dst=/root/.mina-config" \
-minaprotocol/mina-daemon:1.2.2-feee67c-mainnet \
+minaprotocol/mina-daemon:1.2.2-feee67c-devnet \
 daemon \
 --peer-list-url https://storage.googleapis.com/seed-lists/devnet_seeds.txt
 ```


### PR DESCRIPTION
when connecting to the devnet according to the steps mentioned in the docs the node won't connect to the devnet peers and end up crashing 

`[Error] Failed to find any peers during initialization (crashing because this is not a seed node)` because it thinks its on the mainnet. using the devnet mina imagine instead of the mainnet one works.