### PR TITLE
Fix snarkyjs links

### DIFF
--- a/pages/en/snapps/snarkyjs-reference.mdx
+++ b/pages/en/snapps/snarkyjs-reference.mdx
@@ -10,7 +10,7 @@ are a preview of work that is currently in progress.
 
 # SnarkyJS API Reference
 
-To write a Snapp, we recommend using the [Snapp CLI](https://github.com/o1-labs/snapp-cli), which makes writing a Snapp easy by including SnarkyJS & providing project scaffolding, a test framework, and formatting.
+To write a Snapp, we recommend using the [Snapp CLI](https://github.com/o1-labs/snapp-cli), which makes writing a Snapp easy by including [SnarkyJS](https://github.com/o1-labs/snarkyjs) & providing project scaffolding, a test framework, and formatting.
 
 ## Table of contents
 

--- a/src/components/DocsNavs.re
+++ b/src/components/DocsNavs.re
@@ -401,6 +401,8 @@ module Dropdown = {
     let language = toISOCode(currentLanguage);
     let f = url => {j|/$(language)/$(url)|j};
 
+    /* Below is the mobile navigation for mobile and tablets */
+
     <div className=Styles.dropdown>
       <DropdownNav
         currentSlug defaultValue={intl->Intl.formatMessage(minaOverview)}>
@@ -569,6 +571,10 @@ module Dropdown = {
           title={intl->Intl.formatMessage(howWriteSnapp)}
           slug="how-to-write-a-snapp"
         />
+        <Item
+        title={intl->Intl.formatMessage(snappsAPIReference)}
+        slug="snarkyjs-reference"
+      />
         </Section>
         <Item
           title={intl->Intl.formatMessage(troubleshooting)}


### PR DESCRIPTION
Two small changes as requested by Brett:
- Add SnarkyJS Reference page to mobile dropdown menu
- In SnarkyJS Reference page, add a link to: https://github.com/o1-labs/snarkyjs 