### PR TITLE
add warning message to relevant delegation program pages

### DIFF
--- a/pages/en/advanced/bp-sidecar.mdx
+++ b/pages/en/advanced/bp-sidecar.mdx
@@ -4,6 +4,24 @@ export default Page({ title: "Block Producer Sidecar" });
 
 # Block Producer Sidecar
 
+<br></br>
+
+<Alert kind="info">
+<p>
+<b>IMPORTANT UPDATE:</b> This will affect the submission of uptime data and the Performance Score results for receiving a delegation.
+</p>
+<br></br>
+<p>
+The current sidecar tracking system will be phased out after the current cycle (Cycle 6) and be replaced by the SNARK-work-based uptime tracking system. Until further notice, while transitioning to the new system, <b>continue running the <u>sidecar</u> AND <u>SNARK-based tracking system</u> on the SAME node.</b> 
+</p>
+<br></br>
+<p>
+Please follow the instructions in <a href="https://discord.com/channels/484437221055922177/808895957978447882/958384520464330812">this post here</a> and ask any questions in the <a href="https://discord.gg/mXXKHMDU">#delegation-program channel on Discord</a> while following along for the latest updates.
+</p>
+</Alert>
+
+<br></br>
+
 In order to maintain eligibility for various grants and the Foundation Delegation Program, you must run a sidecar with your daemon to report node uptime.
 
 If you are required to keep your node online for a grant or specific program, you must run a small sidecar program that will report your daemon's uptime. This tutorial will walk you through the process of installing, configuring and running the sidecar program.

--- a/pages/en/advanced/foundation-delegation-program.mdx
+++ b/pages/en/advanced/foundation-delegation-program.mdx
@@ -4,6 +4,24 @@ export default Page({title: "Foundation Delegation Program"});
 
 # Guidelines for Participation in Foundation Delegation Program
 
+<br></br>
+
+<Alert kind="info">
+<p>
+<b>IMPORTANT UPDATE:</b> This will affect the submission of uptime data and the Performance Score results for receiving a delegation.
+</p>
+<br></br>
+<p>
+The current sidecar tracking system will be phased out after the current cycle (Cycle 6) and be replaced by the SNARK-work-based uptime tracking system. Until further notice, while transitioning to the new system, <b>continue running the <u>sidecar</u> AND <u>SNARK-based tracking system</u> on the SAME node.</b> 
+</p>
+<br></br>
+<p>
+Please follow the instructions in <a href="https://discord.com/channels/484437221055922177/808895957978447882/958384520464330812">this post here</a> and ask any questions in the <a href="https://discord.gg/mXXKHMDU">#delegation-program channel on Discord</a> while following along for the latest updates.
+</p>
+</Alert>
+
+<br></br>
+
 Check out the [Foundation delegation policy](https://minaprotocol.com/blog/mina-foundation-delegation-policy).  This document has details on exactly what you need to do to pay back rewards if you are receiving a delegation and how to send your uptime data so you can become or remain eligible for recieiving these rewards.
 
 Fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSduM5EIpwZtf5ohkVepKzs3q0v0--FDEaDfbP2VD4V6GcBepA/viewform) if you want to be eligible for future delegation .

--- a/pages/en/advanced/staking-service-guidelines.mdx
+++ b/pages/en/advanced/staking-service-guidelines.mdx
@@ -4,6 +4,24 @@ export default Page({ title: "Staking Service Guidelines" });
 
 # Staking Service Guidelines
 
+<br></br>
+
+<Alert kind="info">
+<p>
+<b>IMPORTANT UPDATE:</b> This will affect the submission of uptime data and the Performance Score results for receiving a delegation.
+</p>
+<br></br>
+<p>
+The current sidecar tracking system will be phased out after the current cycle (Cycle 6) and be replaced by the SNARK-work-based uptime tracking system. Until further notice, while transitioning to the new system, <b>continue running the <u>sidecar</u> AND <u>SNARK-based tracking system</u> on the SAME node.</b> 
+</p>
+<br></br>
+<p>
+Please follow the instructions in <a href="https://discord.com/channels/484437221055922177/808895957978447882/958384520464330812">this post here</a> and ask any questions in the <a href="https://discord.gg/mXXKHMDU">#delegation-program channel on Discord</a> while following along for the latest updates.
+</p>
+</Alert>
+
+<br></br>
+
 An important part of running a staking service is predicting/determining winning slots in which you can produce blocks, as well as paying out participants. The Mina protocol does not automatically payout rewards to delegates, so part of running a staking service is manually paying out participants. 
 
 This document aims to explain the different components that you should think about when managing those payouts. Specifically, this document provides an understanding of odds of winning blocks, gathering data from the ledger for later use, and computing relevant staking payout information from this data.


### PR DESCRIPTION
@MartinMinkov Since we're asking all block producers to move over to the new uptime tracking system, we need to add this warning message until the old tracking system has been phased out.