### PR TITLE
Update correct rest flag

### DIFF
--- a/pages/en/developers/graphql-api.mdx
+++ b/pages/en/developers/graphql-api.mdx
@@ -11,7 +11,7 @@ export default Page({ title: "GraphQL API" });
 
 </Alert>
 
-The Mina daemon exposes a [GraphQL API](https://graphql.org/) used to request information from and submit commands to a running node. By default, an HTTP server runs on port `3085`, though this may be configured by passing the `-rest-server` flag to the daemon startup command.
+The Mina daemon exposes a [GraphQL API](https://graphql.org/) used to request information from and submit commands to a running node. By default, an HTTP server runs on port `3085`, though this may be configured by passing the `-rest-port` flag to the daemon startup command.
 
 To use the GraphQL API, connect your GraphQL client to `http://localhost:3085/graphql` or open in your browser to utilize the [GraphiQL IDE](https://github.com/graphql/graphiql). By default, for security, only connections from `localhost` are permitted. To listen on all interfaces, add the `-insecure-rest-server` flag to the daemon startup command.
 


### PR DESCRIPTION
As of stable release 1.3.1 correct flag for rest server is -rest-port. It may change in future builds, ref: https://github.com/MinaProtocol/mina/commit/03cbbb63113c7d846d4af45ee5b51fd8aaaf3725