### PR TITLE
Updating validate keypair command for Docker

### DIFF
--- a/pages/en/using-mina/keypair.mdx
+++ b/pages/en/using-mina/keypair.mdx
@@ -133,7 +133,7 @@ mina-validate-keypair --privkey-path <path-to-the-private-key-file>
 If you are using Docker run the following command:
 
 ```
-docker run --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.0-9b0369c --privkey-path /keys/my-wallet
+docker run --entrypoint mina-validate-keypair --interactive --tty --rm --volume $(pwd)/keys:/keys minaprotocol/mina-generate-keypair:1.3.0-9b0369c --privkey-path /keys/my-wallet
 ```
 
 ## Next steps


### PR DESCRIPTION
The command in the docs doesn't validate the keypair, would just generate a new one. This fix overwrites the entrypoint to run the `mina-validate-keypair` tool. Thanks to tyaslevesley#7333 in Discord for spotting this.

Fixes: #158 