### PR TITLE
Adds local blockchain and integration testing sections 

### DIFF
--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -78,7 +78,6 @@ txn.send();
 
 While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easier to reason about when creating large interconnected tests. It also makes debugging easier and provides good error tracing. 
 
-
  A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
 
 ```ts
@@ -126,8 +125,6 @@ console.log(`Current State: ${currentState}`);
 shutdown();
 ``` 
 
-### Learn more
-=======
 ## Learn more
 
 

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -40,6 +40,16 @@ Mina.setActiveInstance(Local);
 
 #### Deploying a contract locally
 
+The mock Mina local blockchain contains test accounts that can be used to deploy the contract and pay transaction fees.
+
+```ts
+// test accounts that pays all the fees, and puts additional funds into the zkapp.
+let feePayer = Local.testAccounts[0].privateKey;
+```
+
+
+
+
 #### Writing integration tests
 
 ### Learn more

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -48,14 +48,16 @@ Mina.setActiveInstance(Local);
 
 #### Deploying a contract locally
 
-The mock Mina local blockchain contains test accounts that can be used to deploy the contract and pay transaction fees.
+The mock Mina local blockchain contains test accounts that can be used to deploy smart contracts and pay transaction fees.
+
+First, access a test account provided by the local blockchain.
 
 ```ts
 // Local.testAccounts is an array of 10 test accounts that have been pre-filled with Mina
 let feePayer = Local.testAccounts[0].privateKey;
 ```
 
-We generate a zkApp account and a new instance of the smart contract to deploy locally for testing.
+Next, generate a zkApp account and a new instance of the smart contract to deploy locally for testing.
 
 ```ts
 // zkapp account
@@ -64,7 +66,7 @@ let zkAppAddress = zkAppPrivateKey.toPublicKey();
 let zkAppInstance = new Add(zkAppAddress);
 ```
 
-Use the test account and zkApp keys to construct a transaction to pay account creation fees and deploy your smart contract. This transaction is sent to the local blockchain. 
+Then, use the test account and zkApp keys to construct a transaction to pay account creation fees and deploy your smart contract. This transaction is sent to the local blockchain. 
 
 ```ts
 let txn = await Mina.transaction(feePayer, () => {

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -71,6 +71,8 @@ txn.send();
 
 #### Writing integration tests
 
+While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easy to reason about when creating large interconnected tests for your smart contract. It also makes debugging easier and provides good error tracing.
+
 ### Learn more
 
 Please see the <a href="https://jestjs.io/docs/getting-started">Jest docs</a> for further information on how to use Jest.

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -47,7 +47,14 @@ The mock Mina local blockchain contains test accounts that can be used to deploy
 let feePayer = Local.testAccounts[0].privateKey;
 ```
 
+We generate zkApp account and a new instance of the smart contract to deploy locally.
 
+```ts
+// zkapp account
+let zkAppKey = PrivateKey.random();
+let zkAppAddress = zkAppPrivateKey.toPublicKey();
+let zkAppInstance = new Add(zkAppAddress);
+```
 
 
 #### Writing integration tests

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -51,7 +51,7 @@ We generate a zkApp account and a new instance of the smart contract to deploy l
 
 ```ts
 // zkapp account
-let zkAppKey = PrivateKey.random();
+let zkAppPrivateKey = PrivateKey.random();
 let zkAppAddress = zkAppPrivateKey.toPublicKey();
 let zkAppInstance = new Add(zkAppAddress);
 ```
@@ -61,7 +61,7 @@ Use the test account and zkApp keys to construct a transaction to pay account cr
 ```ts
 let txn = await Mina.transaction(feePayer, () => {
   Party.fundNewAccount(feePayer);
-  zkAppInstance.deploy({ zkappKey });
+  zkAppInstance.deploy({ zkappKey: zkAppPrivateKey});
 });
 txn.send();
 ```

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -83,48 +83,57 @@ While Jest can be used to write both unit and integration tests, It is reccomend
  A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
 
 ```ts
-await isReady;
-// setup local blockchain
-let Local = Mina.LocalBlockchain();
-Mina.setActiveInstance(Local);
+  describe('Add smart contract', () => {
+  let feePayer: PrivateKey,
+    zkAppAddress: PublicKey,
+    zkAppPrivateKey: PrivateKey,
+    zkAppInstance: Add,
+    currentState: Field,
+    txn;
+    
+  beforeAll(async () => {
+    await isReady;
+    // setup local blockchain
+    let Local = Mina.LocalBlockchain();
+    Mina.setActiveInstance(Local);
 
-// test accounts that pays all the fees, and puts additional funds into the zkapp.
-let feePayer = Local.testAccounts[0].privateKey;
+    // Local.testAccounts is an array of 10 test accounts that have been pre-filled with Mina
+    feePayer = Local.testAccounts[0].privateKey;
 
-// zkapp account
-let zkAppPrivateKey = PrivateKey.random();
-let zkAppAddress = zkAppPrivateKey.toPublicKey();
-let zkAppInstance = new Add(zkAppAddress);
+    // zkapp account
+    zkAppPrivateKey = PrivateKey.random();
+    zkAppAddress = zkAppPrivateKey.toPublicKey();
+    zkAppInstance = new Add(zkAppAddress);
 
-// deploy zkapp
-console.log('Deploying Add smart contract ...');
-let tx = await Mina.transaction(feePayer, () => {
-  Party.fundNewAccount(feePayer);
-  zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
-  zkAppInstance.init();
+    // deploy zkapp
+    txn = await Mina.transaction(feePayer, () => {
+      Party.fundNewAccount(feePayer);
+      zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
+      zkAppInstance.init();
+    });
+    await txn.send();
+  });
+
+  afterAll(async () => {
+    setTimeout(shutdown, 0);
+  });
+
+  it('sets intitial state of num to 1', async () => {
+    currentState = zkAppInstance.num.get();
+    expect(currentState).toEqual(Field.one);
+  });
+
+  it('correctly updates num from intial state to 3', async () => {
+    txn = await Mina.transaction(feePayer, () => {
+      zkAppInstance.update();
+      zkAppInstance.sign(zkAppPrivateKey);
+    });
+    txn.send();
+
+    currentState = zkAppInstance.num.get();
+    expect(currentState).toEqual(Field(3));
+  });
 });
-
-tx.send();
-
-let currentState = zkAppInstance.num.get().toString();
-console.log(`Initial state: ${currentState}`);
-
-console.log('Updating state ...');
-tx = await Mina.transaction(feePayer, () => {
-  zkAppInstance.update();
-  zkAppInstance.sign(zkAppPrivateKey);
-});
-
-tx.send();
-
-currentState = zkAppInstance.num.get().toString();
-
-if (currentState !== '3') {
-  throw Error(`'State incorrectly updated to ${currentState}`);
-}
-console.log(`Current State: ${currentState}`);
-
-shutdown();
 ``` 
 
 ## Learn more

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -51,7 +51,7 @@ Mina.setActiveInstance(Local);
 The mock Mina local blockchain contains test accounts that can be used to deploy the contract and pay transaction fees.
 
 ```ts
-// test accounts that pays all the fees, and puts additional funds into the zkapp.
+// Local.testAccounts is an array of 10 test accounts that have been pre-filled with Mina
 let feePayer = Local.testAccounts[0].privateKey;
 ```
 

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -47,7 +47,7 @@ The mock Mina local blockchain contains test accounts that can be used to deploy
 let feePayer = Local.testAccounts[0].privateKey;
 ```
 
-We generate a zkApp account and a new instance of the smart contract to deploy locally.
+We generate a zkApp account and a new instance of the smart contract to deploy locally for testing.
 
 ```ts
 // zkapp account
@@ -56,7 +56,7 @@ let zkAppAddress = zkAppPrivateKey.toPublicKey();
 let zkAppInstance = new Add(zkAppAddress);
 ```
 
-Construct a transaction to pay account creation fees and deploy your smart contract. This transaction is sent to the local blockchain. 
+Use the test account and zkApp keys to construct a transaction to pay account creation fees and deploy your smart contract. This transaction is sent to the local blockchain. 
 
 ```ts
 let txn = await Mina.transaction(feePayer, () => {
@@ -66,12 +66,12 @@ let txn = await Mina.transaction(feePayer, () => {
 txn.send();
 ```
 
-
-
-
 #### Writing integration tests
 
-While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easy to reason about when creating large interconnected tests for your smart contract. It also makes debugging easier and provides good error tracing.
+While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easier to reason about when creating large interconnected tests. It also makes debugging easier and provides good error tracing. 
+
+
+ A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example integration test script.
 
 ### Learn more
 

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -29,6 +29,12 @@ Because we are using Jest, it's helpful to break down all functionality of your 
 
 For examples of existing tests, we recommend creating a template example using the Mina zkApp CLI via `zk project <name>` and examining the test file there. [You will see a basic example of a few tests](https://github.com/o1-labs/zkapp-cli/blob/main/templates/project-ts/src/Add.test.ts) that deploy and update the state on a smart contract using Jest.
 
+#### Creating a local blockchain
+
+#### Deploying a contract locally
+
+#### Writing integration tests
+
 ### Learn more
 
 Please see the <a href="https://jestjs.io/docs/getting-started">Jest docs</a> for further information on how to use Jest.

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -79,19 +79,17 @@ txn.send();
 
 #### Writing integration tests
 
-While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easier to reason about when creating large interconnected tests. It also makes debugging easier and provides good error tracing. 
-
- A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
+Jest can be used to write both unit and integration tests. A well written integration test tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
 
 ```ts
-  describe('Add smart contract', () => {
+  describe('Add smart contract integration test', () => {
   let feePayer: PrivateKey,
     zkAppAddress: PublicKey,
     zkAppPrivateKey: PrivateKey,
     zkAppInstance: Add,
     currentState: Field,
     txn;
-    
+  
   beforeAll(async () => {
     await isReady;
     // setup local blockchain

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -31,6 +31,13 @@ For examples of existing tests, we recommend creating a template example using t
 
 #### Creating a local blockchain
 
+The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts that runs locally. It contains logic for updating the ledger that can be used to test your smart contract locally.
+
+```ts
+let Local = Mina.LocalBlockchain();
+Mina.setActiveInstance(Local);
+```
+
 #### Deploying a contract locally
 
 #### Writing integration tests

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -39,7 +39,8 @@ For examples of existing tests, we recommend creating a template example using t
 
 #### Creating a local blockchain
 
-The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts that runs locally. It contains logic for updating the ledger that can be used to test your smart contract locally.
+It's helpful to run your smart contract locally on a mock blockchain to quickly test it. 
+The `Mina.LocalBlockchain()` method specifies a mock Mina ledger of accounts that runs locally on your machine. It contains logic for updating the ledger that can be used to test your smart contract.
 
 ```ts
 let Local = Mina.LocalBlockchain();

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -71,7 +71,52 @@ txn.send();
 While Jest can be used to write both unit and integration tests, It is reccomended to create linear scripts for smart contract integration tests. The scripting worflow is easier to reason about when creating large interconnected tests. It also makes debugging easier and provides good error tracing. 
 
 
- A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example integration test script.
+ A well written script tests the flow of your smart contracts expected behavior, and verifies correctness of state updates. After you test the expected behavior, it's benifical to verify the preconditions of your methods and test edge cases of your smart contract. Below is an example of a basic integration test script.
+
+```ts
+await isReady;
+// setup local blockchain
+let Local = Mina.LocalBlockchain();
+Mina.setActiveInstance(Local);
+
+// test accounts that pays all the fees, and puts additional funds into the zkapp.
+let feePayer = Local.testAccounts[0].privateKey;
+
+// zkapp account
+let zkAppPrivateKey = PrivateKey.random();
+let zkAppAddress = zkAppPrivateKey.toPublicKey();
+let zkAppInstance = new Add(zkAppAddress);
+
+// deploy zkapp
+console.log('Deploying Add smart contract ...');
+let tx = await Mina.transaction(feePayer, () => {
+  Party.fundNewAccount(feePayer);
+  zkAppInstance.deploy({ zkappKey: zkAppPrivateKey });
+  zkAppInstance.init();
+});
+
+tx.send();
+
+let currentState = zkAppInstance.num.get().toString();
+console.log(`Initial state: ${currentState}`);
+
+console.log('Updating state ...');
+tx = await Mina.transaction(feePayer, () => {
+  zkAppInstance.update();
+  zkAppInstance.sign(zkAppPrivateKey);
+});
+
+tx.send();
+
+currentState = zkAppInstance.num.get().toString();
+
+if (currentState !== '3') {
+  throw Error(`'State incorrectly updated to ${currentState}`);
+}
+console.log(`Current State: ${currentState}`);
+
+shutdown();
+``` 
 
 ### Learn more
 

--- a/pages/en/zkapps/how-to-test-a-zkapp.mdx
+++ b/pages/en/zkapps/how-to-test-a-zkapp.mdx
@@ -47,7 +47,7 @@ The mock Mina local blockchain contains test accounts that can be used to deploy
 let feePayer = Local.testAccounts[0].privateKey;
 ```
 
-We generate zkApp account and a new instance of the smart contract to deploy locally.
+We generate a zkApp account and a new instance of the smart contract to deploy locally.
 
 ```ts
 // zkapp account
@@ -55,6 +55,18 @@ let zkAppKey = PrivateKey.random();
 let zkAppAddress = zkAppPrivateKey.toPublicKey();
 let zkAppInstance = new Add(zkAppAddress);
 ```
+
+Construct a transaction to pay account creation fees and deploy your smart contract. This transaction is sent to the local blockchain. 
+
+```ts
+let txn = await Mina.transaction(feePayer, () => {
+  Party.fundNewAccount(feePayer);
+  zkAppInstance.deploy({ zkappKey });
+});
+txn.send();
+```
+
+
 
 
 #### Writing integration tests


### PR DESCRIPTION
Closes
#179 

Adds sections on setting up a local blockchain, deploying locally, and writing integration tests to the "How to test a zkApp page".