### PR TITLE
@state needs to be AsFieldElements

### DIFF
--- a/pages/en/zkapps/simple-anonymous-message-board-tutorial.mdx
+++ b/pages/en/zkapps/simple-anonymous-message-board-tutorial.mdx
@@ -188,9 +188,9 @@ export class Add extends SmartContract {
   // On-chain state definitions
   @state(Field) message = State<Field>();
   @state(Field) messageHistoryHash = State<Field>();
-  @state(PublicKey) user1 = State<PublicKey>();
-  @state(PublicKey) user2 = State<PublicKey>();
-  @state(PublicKey) user3 = State<PublicKey>();
+  @state(Group) user1 = State<PublicKey>();
+  @state(Group) user2 = State<PublicKey>();
+  @state(Group) user3 = State<PublicKey>();
 ```
 
 The `@state(Field)` decorator tells SnarkyJS that the variable should be stored on-chain as a `Field` type.


### PR DESCRIPTION
`Group` is `AsFieldElements<Group>` but `PublicKey` is not `AsFieldElements<PublicKey>`, because `PublicKey` lacks the `check(x: PublicKey): void;`. But `Group` has a `check(x: Group): void;`

So either `PublicKey` needs `check(x: PublicKey): void;` or 
this proposed change to the documentation has to be accepted.